### PR TITLE
Remove Manual Flashlight radius & Shadows checkbox, & more

### DIFF
--- a/src/mods/ManualFlashlight.hpp
+++ b/src/mods/ManualFlashlight.hpp
@@ -4,6 +4,19 @@
 
 #include "Mod.hpp"
 
+#ifdef RE8
+
+class AppPlayerHandLight2 : public AppBehaviorApp {
+public:
+    char pad_0050[1];                                      // 0x0050
+	bool IsContinuousOn;                                   // 0x0051
+	char pad_0052[6];                                      // 0x0052
+	AppHandLightPowerController *handLightPowerController; // 0x0058
+	char pad_0060[4];                                      // 0x0060
+	int32_t EnterHandLightPowerOnZoneCount;                // 0x0064
+};
+#endif
+
 // Original founder (RE2): SkacikPL (https://github.com/SkacikPL)
 // Recreated in REFramework
 class ManualFlashlight : public Mod {
@@ -24,6 +37,7 @@ private:
     const ModToggle::Ptr m_enabled{ ModToggle::create(generate_name("Enabled"), false) };
 
 #ifdef RE8
+    const ModToggle::Ptr m_light_ignore_power_on_zones{ ModToggle::create(generate_name("IgnorePowerOnZones"), false) };
     const ModToggle::Ptr m_light_enable_shadows{ ModToggle::create(generate_name("LightShadows"), true) };
     const ModSlider::Ptr m_light_radius{ ModSlider::create(generate_name("LightRadius"), 0.0f, 50.0f, 1.0f) };
 #endif
@@ -32,6 +46,7 @@ private:
         *m_key,
         *m_enabled,
 #ifdef RE8
+        *m_light_ignore_power_on_zones,
         *m_light_enable_shadows,
         *m_light_radius,
 #endif
@@ -42,8 +57,9 @@ private:
 #else
     AppPropsManager* m_props_manager{nullptr};
     REGameObject* m_player{nullptr};
-    AppPlayerHandLight* m_player_hand_light{nullptr};
-    IESLight* m_player_hand_ies_light{nullptr};
+    AppPlayerHandLight2* m_player_hand_light{nullptr};
+
+    int32_t m_light_power_on_zones{ 0 };
 #endif
 
     void on_disabled() noexcept;

--- a/src/mods/ManualFlashlight.hpp
+++ b/src/mods/ManualFlashlight.hpp
@@ -5,7 +5,6 @@
 #include "Mod.hpp"
 
 #ifdef RE8
-
 class AppPlayerHandLight2 : public AppBehaviorApp {
 public:
     char pad_0050[1];                                      // 0x0050
@@ -38,8 +37,6 @@ private:
 
 #ifdef RE8
     const ModToggle::Ptr m_light_ignore_power_on_zones{ ModToggle::create(generate_name("IgnorePowerOnZones"), false) };
-    const ModToggle::Ptr m_light_enable_shadows{ ModToggle::create(generate_name("LightShadows"), true) };
-    const ModSlider::Ptr m_light_radius{ ModSlider::create(generate_name("LightRadius"), 0.0f, 50.0f, 1.0f) };
 #endif
 
     ValueList m_options{
@@ -47,8 +44,6 @@ private:
         *m_enabled,
 #ifdef RE8
         *m_light_ignore_power_on_zones,
-        *m_light_enable_shadows,
-        *m_light_radius,
 #endif
     };
 


### PR DESCRIPTION
After testing, these features really break the manual flashlight in certain areas where the flashlight is forced on. To keep things simple, let's just remove them for now. A radius slider is pretty silly anyway considering theres dozens of other options for lights.

This also allows the manual flashlight to ignore force toggle on zones... at the expense of not being able to restore such functionality without a restart.